### PR TITLE
Notice: DISABLE_WP_CRON already defined

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -53,7 +53,9 @@ class Router {
 		}
 
 		// disable cronjobs for this request
-		define( 'DISABLE_WP_CRON', true );
+		if(!defined('DISABLE_WP_CRON')){
+			define( 'DISABLE_WP_CRON', true );
+		}
 
 		// filter active plugins
 		add_filter( 'option_active_plugins', function() use ( $endpoint ) {


### PR DESCRIPTION
The constant DISABLE_WP_CRON should be checked if it is defined before use.

The error log fills up with the notice above in some cases (e.g. other plugins are using the constant, too)
