### PR TITLE
Removes comma that causes syntax error from the example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ $router->register_endpoint(
 	'/edd-sl-api', 	// listen to requests starting with /edd-sl-api
 	array(
 		'easy-digital-downloads/easy-digital-downloads.php',
-		'edd-software-licensing/edd-software-licenses.php' 
-	),				// only enable edd & edd sl plugins
+		'edd-software-licensing/edd-software-licenses.php'
+	)				// only enable edd & edd sl plugins
 );
 
 // done! 


### PR DESCRIPTION
No issue. Copying and pasting the example code as-is produces a syntax error because it's listing arguments to a function and not listing elements of an array (where a trailing comma is expected).
