### PR TITLE
define DOING_AJAX when custom endpoint is used

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -32,6 +32,7 @@ class Router {
 
 		foreach( $this->endpoints as $endpoint ) {
 			if( strpos( $_SERVER['REQUEST_URI'], $endpoint->url ) === 0 ) {
+				define( 'DOING_AJAX', true );
 				return $endpoint;
 			}
 		}


### PR DESCRIPTION
Without this, mechanisms (buddypress in my case) that check to see if AJAX is called don't work. I can't really foresee how defining this would ever interfere negatively with anyone's site.